### PR TITLE
fix(bug-trailing-newline-csv): use option from library to skip bad rows from CSV

### DIFF
--- a/budget-parse/src/app.ts
+++ b/budget-parse/src/app.ts
@@ -114,6 +114,7 @@ app.get('/', (req, res) => {
   parse(fileContent, {
     delimiter: ',',
     columns: headers,
+    skipRecordsWithError: true
   }, (error, result: Transaction[]) => {
     if (error) throw error;
 


### PR DESCRIPTION
Fixes an issue with generated CSV files with a trailing newline by ignoring those rows. These rows led to `CSV_RECORD_INCONSISTENT_COLUMNS` error due to an empty row.